### PR TITLE
WL-3566 : Add email sent confirmation message to feedback tool

### DIFF
--- a/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
+++ b/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
@@ -101,6 +101,7 @@ public class FeedbackTool extends HttpServlet {
         request.setAttribute("helpdeskUrl", sakaiProxy.getConfigString("feedback.helpdeskUrl", ""));
         request.setAttribute("supplementaryInfo", sakaiProxy.getConfigString("feedback.supplementaryInfo", ""));
         request.setAttribute("maxAttachmentsMB", sakaiProxy.getAttachmentLimit());
+        request.setAttribute("technicalToAddress", sakaiProxy.getConfigString(Constants.PROP_TECHNICAL_ADDRESS, null));
 
         response.setContentType("text/html");
         request.getRequestDispatcher("/WEB-INF/bootstrap.jsp").include(request, response);

--- a/src/webapp/WEB-INF/bootstrap.jsp
+++ b/src/webapp/WEB-INF/bootstrap.jsp
@@ -22,6 +22,7 @@
                 siteId: '${siteId}',
                 language: '${language}',
                 featureSuggestionUrl: '${featureSuggestionUrl}',
+                technicalToAddress: '${technicalToAddress}',
                 enableTechnical: ${enableTechnical},
                 helpdeskUrl: '${helpdeskUrl}',
                 helpPagesUrl: '${helpPagesUrl}',
@@ -54,6 +55,11 @@
                 <div id="feedback-error-message-wrapper">
                     <div>
                         <img src="/library/image/silk/exclamation.png" /><span></span><a id="feedback-error-close" href="javascript:;"><img src="/library/image/silk/cross.png" /></a>
+                    </div>
+                </div>
+                <div id="feedback-info-message-wrapper">
+                    <div>
+                        <img src="/library/image/silk/information.png" /><span></span><a id="feedback-info-close" href="javascript:;"><img src="/library/image/silk/cross.png" /></a>
                     </div>
                 </div>
                 <div id="feedback-content"></div>

--- a/src/webapp/WEB-INF/templates/technical.handlebars
+++ b/src/webapp/WEB-INF/templates/technical.handlebars
@@ -17,6 +17,7 @@
         <div>Enter the text that you see in the box below:</div>
         <div id="feedback-recaptcha-block"></div>
     </div>
+	<input id="feedback-technical-email" value="{{technicalToAddress}}" hidden="hidden"/>
     <div id="feedback-attachments-label">
         <span>{{translate 'attachments_label'}}</span>
         <span id="feedback-max-attachments-label">

--- a/src/webapp/css/feedback.css
+++ b/src/webapp/css/feedback.css
@@ -41,7 +41,7 @@
     margin-bottom: 10px;
 }
 
-#feedback-error-message-wrapper {
+#feedback-error-message-wrapper, #feedback-info-message-wrapper {
     display: none;
     text-align: center;
     margin-top: 10px;
@@ -55,12 +55,20 @@
     color: red;
 }
 
-#feedback-error-message-wrapper span {
+#feedback-info-message-wrapper > div{
+    display: inline-block;
+    padding: 5px;
+    border: 1px green solid;
+    border-radius: 1em 1em 1em 1em;
+    color: green;
+}
+
+#feedback-error-message-wrapper span, #feedback-info-message-wrapper span {
     margin-right: 10px;
     margin-left: 10px;
 }
 
-#feedback-error-message-wrapper img {
+#feedback-error-message-wrapper img, #feedback-info-message-wrapper img {
     margin: 0px;
     padding: 0px;
 }

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -19,6 +19,8 @@
     var NO_SENDER_ADDRESS = 'NO_SENDER_ADDRESS';
 
     var loggedIn = (feedback.userId != '') ? true : false;
+    var siteUpdater;
+    var technicalToAddress;
 
     feedback.switchState = function (state) {
 
@@ -28,7 +30,14 @@
 
         $('#feedback-error-message-wrapper').hide();
 
+        $('#feedback-info-message-wrapper').hide();
+
         if (HOME === state) {
+
+            siteUpdater = $('#feedback-siteupdaters').find(':selected').text();
+
+            technicalToAddress = $('#feedback-technical-email').val();
+
             feedback.utils.renderTemplate(HOME, { featureSuggestionUrl: feedback.featureSuggestionUrl,
                                                     supplementaryInfo: feedback.supplementaryInfo,
                                                     helpPagesUrl: feedback.helpPagesUrl,
@@ -75,6 +84,9 @@
                 });
 
                 feedback.fitFrame();
+
+                feedback.displayInfo(siteUpdater);
+                feedback.displayInfo(technicalToAddress);
             });
         } else if (CONTENT === state) {
 
@@ -103,7 +115,7 @@
             });
         } else if (TECHNICAL === state) {
 
-            feedback.utils.renderTemplate(state, { siteId: feedback.siteId }, 'feedback-content');
+            feedback.utils.renderTemplate(state, { siteId: feedback.siteId, technicalToAddress: feedback.technicalToAddress  }, 'feedback-content');
 
             $(document).ready(function () {
 
@@ -241,6 +253,20 @@
         if (feedback.recaptchaPublicKey.length > 0) {
             // Recaptcha is enabled, so we need to reset it.
             Recaptcha.reload();
+        }
+    };
+
+
+    feedback.displayInfo = function (siteUpdater) {
+		if (siteUpdater!=null && siteUpdater!=''){
+            $('#feedback-info-message-wrapper span').html('An email with the information you entered has been sent to ' + siteUpdater);
+
+            $('#feedback-info-message-wrapper a').click(function (e) {
+                $('#feedback-info-message-wrapper').hide();
+            });
+
+            $('#feedback-info-message-wrapper').show();
+            feedback.fitFrame();
         }
     };
 

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -258,7 +258,7 @@
 
 
     feedback.displayInfo = function (siteUpdater) {
-		if (siteUpdater!=null && siteUpdater!=''){
+        if (siteUpdater!=null && siteUpdater!=''){
             $('#feedback-info-message-wrapper span').html('An email with the information you entered has been sent to ' + siteUpdater);
 
             $('#feedback-info-message-wrapper a').click(function (e) {

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -83,10 +83,10 @@
                                             } });
                 });
 
-                feedback.fitFrame();
-
                 feedback.displayInfo(siteUpdater);
                 feedback.displayInfo(technicalToAddress);
+
+                feedback.fitFrame();
             });
         } else if (CONTENT === state) {
 

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -88,8 +88,12 @@
                     $('#feedback-info-message-wrapper').hide();
                 });
 
-                feedback.displayInfo(siteUpdater);
-                feedback.displayInfo(technicalToAddress);
+                if (siteUpdater!=null && siteUpdater!='') {
+                    feedback.displayInfo(siteUpdater);
+                }
+                else {
+                    feedback.displayInfo(technicalToAddress);
+                }
 
                 feedback.fitFrame();
             });

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -83,6 +83,11 @@
                                             } });
                 });
 
+
+                $('#feedback-info-message-wrapper a').click(function (e) {
+                    $('#feedback-info-message-wrapper').hide();
+                });
+
                 feedback.displayInfo(siteUpdater);
                 feedback.displayInfo(technicalToAddress);
 
@@ -260,11 +265,6 @@
     feedback.displayInfo = function (siteUpdater) {
         if (siteUpdater!=null && siteUpdater!=''){
             $('#feedback-info-message-wrapper span').html('An email with the information you entered has been sent to ' + siteUpdater);
-
-            $('#feedback-info-message-wrapper a').click(function (e) {
-                $('#feedback-info-message-wrapper').hide();
-            });
-
             $('#feedback-info-message-wrapper').show();
             feedback.fitFrame();
         }


### PR DESCRIPTION
This is only for logged in users. WL-3576 is for non logged in users.

I'm grabbing the siteUpdaters after form submission in the js and showing it in an info box at the top.

For the technical toAddress, same thing except that the email address is normally got in Java after the submission so I'm using the same one-liner to put it in the request before, before getting it out again in the js afterwards.

I'm re-using as much of the css for the error message as possible.
