### PR TITLE
WL-3592 : contact list is empty

### DIFF
--- a/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
+++ b/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
@@ -59,13 +59,7 @@ public class FeedbackTool extends HttpServlet {
 
         if (userId != null) {
 
-            Map<String, String> siteUpdaters = new HashMap<String, String>();
-
-            if (sakaiProxy.getSiteProperty(siteId, Site.PROP_SITE_CONTACT_EMAIL) == null) {
-                // No contact email. Load up the maintainers so the reporter can
-                // pick one
-                siteUpdaters = sakaiProxy.getSiteUpdaters(siteId);
-            }
+            Map<String, String> siteUpdaters = sakaiProxy.getSiteUpdaters(siteId);
 
             ResourceLoader rl = new ResourceLoader("org.sakaiproject.feedback.bundle.ui");
 


### PR DESCRIPTION
This is because at the moment the logic in the tool is to only show the site maintainers if the site has no email but this requirement has changed.

Now they are shown if the user is logged in and has the right permission (the permission bit is in another JIRA ; for now, just show the site maintainers if the user is logged in). .
