### PR TITLE
contact_us_email_from_address_bug : Change from-address to the actual sender

### DIFF
--- a/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -167,6 +167,8 @@ public class SakaiProxy {
             userId = user.getId();
             userEid = user.getEid();
         }
+        final String smtpFrom = emailService.getSmtpFrom();
+        emailService.setSmtpFrom(fromAddress);
 
         if (fromAddress == null) {
             logger.error("No email for reporter: " + fromUserId + ". No email will be sent.");
@@ -272,6 +274,10 @@ public class SakaiProxy {
 			        emailService.send(msg, true);
                 } catch (Exception e) {
                     logger.error("Failed to send email.", e);
+                }
+                finally {
+                // Reset envelope return address to original value
+                emailService.setSmtpFrom(smtpFrom);
                 }
             }
         }, "Feedback Email Thread").start();


### PR DESCRIPTION
The bug is that emails from the Contact Us tool are being shown as
from "WebLearnweblearn-noreply@it.ox.ac.uk" whereas they should  
show the sender's email address

Here I am  setting the basicService's smptFrom before the email then after the email is sent we reutnr it to
its original value. 

Linked to https://github.com/ox-it/wl-kernel/pull/49
