### PR TITLE
WL-3623 : List of maintainers is blank if site contains a deleted user

### DIFF
--- a/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -1,11 +1,6 @@
 package org.sakaiproject.feedback.util;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.ResourceBundle;
-import java.util.Map;
+import java.util.*;
 import java.text.MessageFormat;
 
 import org.apache.commons.fileupload.FileItem;
@@ -121,8 +116,9 @@ public class SakaiProxy {
         try {
             Site site = siteService.getSite(siteId);
             Map<String, String> map = new HashMap<String, String>();
-            for (String userId : site.getUsersIsAllowed(SiteService.SECURE_UPDATE_SITE)) {
-                User user = userDirectoryService.getUser(userId);
+            Set<String> userIds = site.getUsersIsAllowed(SiteService.SECURE_UPDATE_SITE);
+            List<User> users = userDirectoryService.getUsers(userIds);
+            for (User user : users) {
                 String email = user.getEmail();
                 if (email != null && email.length() > 0) {
                     map.put(user.getId(), user.getDisplayName());


### PR DESCRIPTION
The problem is that if you go to the Contact Us tool for a site that has
a (maintainer/contributor) user that has been deleted, then the site gets
its users (including the deleted one) and tries to look up information on
that user, throws a UserNotDefinedException, and returns an empty list.
This means that a site with one deleted user doesn't show
any of the other non-deleted maintainers in the Contact Us tool.

This fix makes use of userDirectoryService.getUsers() to get the
users (instead of userDirectoryService.getUser(userId) for each user)  - which gets the users from the db and does not throw an exception if it can't find a particualr user.
