### PR TITLE
WL-3621 : helpdesk pages shouldnt have dropdown list of maintainers or site contact listed

### DIFF
--- a/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
+++ b/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
@@ -130,7 +130,6 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
         // The senderAddress can be either picked up from the current user's
         // account, or manually entered by the user submitting the report.
         String senderAddress = null;
-        toAddress = sakaiProxy.getSiteProperty(siteId, Site.PROP_SITE_CONTACT_EMAIL);
 
         if (userId != null) {
             senderAddress = sakaiProxy.getUser(userId).getEmail();
@@ -150,10 +149,7 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
                     return BAD_RECIPIENT;
                 }
             } else {
-                toAddress = sakaiProxy.getSiteProperty(siteId, Site.PROP_SITE_CONTACT_EMAIL);
-                if (toAddress==null){
-                    toAddress = sakaiProxy.getConfigString(Constants.PROP_TECHNICAL_ADDRESS, null);
-                }
+                toAddress = getToAddress(type, siteId);
             }
         }
         else {
@@ -180,10 +176,7 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
                 return BAD_REQUEST;
             }
 
-            toAddress = sakaiProxy.getSiteProperty(siteId, Site.PROP_SITE_CONTACT_EMAIL);
-            if (toAddress==null){
-                toAddress = sakaiProxy.getConfigString(Constants.PROP_TECHNICAL_ADDRESS, null);
-            }
+            toAddress = getToAddress(type, siteId);
         }
 
         if (toAddress == null || toAddress.isEmpty()) {
@@ -212,7 +205,21 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
         }
     }
 
-	private List<FileItem> getAttachments(final Map<String, Object> params) throws Exception {
+    private String getToAddress(String type, String siteId) {
+        String toAddress;
+        if (Constants.CONTENT.equals(type)){
+            toAddress = sakaiProxy.getSiteProperty(siteId, Site.PROP_SITE_CONTACT_EMAIL);
+            if (toAddress==null){
+                toAddress = sakaiProxy.getConfigString(Constants.PROP_TECHNICAL_ADDRESS, null);
+            }
+        }
+        else {
+            toAddress = sakaiProxy.getConfigString(Constants.PROP_TECHNICAL_ADDRESS, null);
+        }
+        return toAddress;
+    }
+
+    private List<FileItem> getAttachments(final Map<String, Object> params) throws Exception {
 
 		final List<FileItem> fileItems = new ArrayList<FileItem>();
 

--- a/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
+++ b/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
@@ -219,7 +219,7 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
         return toAddress;
     }
 
-    private List<FileItem> getAttachments(final Map<String, Object> params) throws Exception {
+	private List<FileItem> getAttachments(final Map<String, Object> params) throws Exception {
 
 		final List<FileItem> fileItems = new ArrayList<FileItem>();
 

--- a/src/webapp/WEB-INF/templates/technical.handlebars
+++ b/src/webapp/WEB-INF/templates/technical.handlebars
@@ -3,18 +3,6 @@
 <form id="feedback-form" action="/direct/feedback/{{siteId}}/reporttechnical" method="POST">
     <div id="feedback-mandatory-instruction" class="instruction">{{translate 'mandatory_instruction'}}</div>
     <table id="feedback-field-table" cols="2">
-    {{#if loggedIn}}
-        <tr>
-            <td id="feedback-siteupdater-instruction"><label for="feedback-siteupdaters">{{translate 'siteupdater_instruction'}}</label></td>
-            <td>
-                <select id="feedback-siteupdaters" name="alternativerecipient">
-                    {{#each siteUpdaters}}
-                        <option value="{{id}}">{{displayName}}</option>
-                    {{/each}}
-                </select>
-            </td>
-        </tr>
-    {{/if}}
         <tr>
             <td id="feedback-title-label"><label for="feedback-title">{{translate 'title_label'}}</label></td>
             <td id="feedback-title-field"><input id="feedback-title" type="text" name="title" maxlength="40" size="40"/></td>
@@ -24,14 +12,6 @@
             <td id="feedback-description-field"><textarea id="feedback-description" name="description" cols="80" rows="5"></textarea></td>
         </tr>
         <tr id="feedback-sender-address"><td>{{translate 'sender_address_label'}}</td><td><input type="text" name="senderaddress" size="40"/></td></tr>
-        {{#if contactName}}
-            <tr>
-                <td id="feedback-contact-name-label"><label for="feedback-contact-name">{{translate 'contact_name_label'}}</label></td>
-                <td id="feedback-contact-name-field">
-                    <div id="feedback-mandatory-instruction" class="instruction">{{contactName}}</div>
-                </td>
-            </tr>
-        {{/if}}
     </table>
     <input id="feedback-technical-email" value="{{technicalToAddress}}" hidden="hidden"/>
     <div id="feedback-attachments-label">


### PR DESCRIPTION
Couple of changes:
1.   For just the Technical Report, they should not have the drop down list and should not list the site contact so I've deleted these.
2.   For just the Technical Report, the email should always go to the weblearn email.
So in FeedbackEntityProvider.java, I've got some common logic for where the email should go for both reports.

Ps. The indentation for this file is inconsistent
