### PR TITLE
WL-3642 : wrong subject line for help request

### DIFF
--- a/src/java/mysql/createtables.sql
+++ b/src/java/mysql/createtables.sql
@@ -1,1 +1,1 @@
-CREATE TABLE IF NOT EXISTS sakai_feedback (id INT NOT NULL AUTO_INCREMENT, user_id VARCHAR(99), email VARCHAR(255) NOT NULL, site_id VARCHAR(99) NOT NULL, report_type ENUM('content','technical') NOT NULL, title VARCHAR(40) NOT NULL, content TINYTEXT NOT NULL, PRIMARY KEY(id));
+CREATE TABLE IF NOT EXISTS sakai_feedback (id INT NOT NULL AUTO_INCREMENT, user_id VARCHAR(99), email VARCHAR(255) NOT NULL, site_id VARCHAR(99) NOT NULL, report_type ENUM('content','technical', 'helpdesk') NOT NULL, title VARCHAR(40) NOT NULL, content TINYTEXT NOT NULL, PRIMARY KEY(id));

--- a/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
+++ b/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
@@ -101,6 +101,11 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
         return handleReport(view, params, Constants.TECHNICAL);
 	}
 
+	@EntityCustomAction(action = "reporthelpdesk", viewKey = EntityView.VIEW_EDIT)
+	public String handleHelpReport(EntityView view, Map<String, Object> params) {
+		return handleReport(view, params, Constants.HELPDESK);
+	}
+
 	private String handleReport(final EntityView view, final Map<String, Object> params, final String type) {
 
 		final String userId = developerHelperService.getCurrentUserId();

--- a/src/java/org/sakaiproject/feedback/util/Constants.java
+++ b/src/java/org/sakaiproject/feedback/util/Constants.java
@@ -4,5 +4,6 @@ public class Constants {
 
 	public final static String CONTENT = "content";
 	public final static String TECHNICAL = "technical";
+	public final static String HELPDESK = "helpdesk";
     public final static String PROP_TECHNICAL_ADDRESS = "feedback.technicalAddress";
 }

--- a/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -195,6 +195,8 @@ public class SakaiProxy {
         
         if (feedbackType.equals(Constants.CONTENT)) {
             subjectTemplate = rb.getString("content_email_subject_template");
+        } else if (feedbackType.equals(Constants.HELPDESK)) {
+            subjectTemplate = rb.getString("help_email_subject_template");
         } else {
             subjectTemplate = rb.getString("technical_email_subject_template");
         }

--- a/src/main/resources/org/sakaiproject/feedback.properties
+++ b/src/main/resources/org/sakaiproject/feedback.properties
@@ -94,6 +94,7 @@ attachments_max_suffix=MB allowed
 #EMAIL PROPERTIES
 content_email_subject_template=Content problem report from {0}
 technical_email_subject_template=Technical problem report from {0}
+help_email_subject_template=Help request from {0}
 no_contact_email_message=You have received this email because no contact email was specified for the problem site
 email_body_template= \
 {0}\

--- a/src/main/resources/org/sakaiproject/feedback_en_GB.properties
+++ b/src/main/resources/org/sakaiproject/feedback_en_GB.properties
@@ -94,6 +94,7 @@ attachments_max_suffix=MB allowed
 #EMAIL PROPERTIES
 content_email_subject_template=Content problem report from {0}
 technical_email_subject_template=Technical problem report from {0}
+help_email_subject_template=Help request from {0}
 no_contact_email_message=You have received this email because no contact email was specified for the problem site
 email_body_template= \
 {0}\

--- a/src/webapp/WEB-INF/templates/technical.handlebars
+++ b/src/webapp/WEB-INF/templates/technical.handlebars
@@ -1,6 +1,6 @@
 <h2 id="feedback-title">{{translate 'title'}}</h2>
 <div id="feedback-overview" class="instruction">{{translate 'technical_instruction'}}</div>
-<form id="feedback-form" action="/direct/feedback/{{siteId}}/reporttechnical" method="POST">
+<form id="feedback-form" action="/direct/feedback/{{siteId}}/{{url}}" method="POST">
     <div id="feedback-mandatory-instruction" class="instruction">{{translate 'mandatory_instruction'}}</div>
     <table id="feedback-field-table" cols="2">
         <tr>

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -6,6 +6,8 @@
     var HOME = 'home';
     var CONTENT = 'content';
     var TECHNICAL = 'technical';
+    var REPORTTECHNICAL = 'reporttechnical';
+    var REPORTHELPDESK = 'reporthelpdesk';
 
     /* RESPONSE CODES */
     var SUCCESS = 'SUCCESS';
@@ -25,6 +27,10 @@
     var technicalToAddress;
 
     feedback.switchState = function (state) {
+        feedback.switchState(state, null);
+    }
+
+    feedback.switchState = function (state, url) {
 
         $('#feedback-toolbar > li > span').removeClass('current');
 
@@ -60,8 +66,11 @@
                 if (feedback.enableTechnical) {
                     $('#feedback-technical-item').show().css('display', 'inline');
                     $('#feedback-report-technical-wrapper').show();
-                    $('#feedback-report-technical-link, #feedback-report-helpdesk-link').click(function (e) {
-                        feedback.switchState(TECHNICAL);
+                    $('#feedback-report-technical-link').click(function (e) {
+                        feedback.switchState(TECHNICAL, REPORTTECHNICAL);
+                    });
+                    $('#feedback-report-helpdesk-link').click(function (e) {
+                        feedback.switchState(TECHNICAL, REPORTHELPDESK);
                     });
                 } else {
                     $('#feedback-technical-setup-instruction').show();
@@ -133,7 +142,7 @@
             });
         } else if (TECHNICAL === state) {
 
-            feedback.utils.renderTemplate(state, { siteId: feedback.siteId, siteUpdaters: feedback.siteUpdaters, loggedIn: loggedIn, technicalToAddress: feedback.technicalToAddress, contactName: feedback.contactName }, 'feedback-content');
+            feedback.utils.renderTemplate(state, { url: url, siteId: feedback.siteId, siteUpdaters: feedback.siteUpdaters, loggedIn: loggedIn, technicalToAddress: feedback.technicalToAddress, contactName: feedback.contactName }, 'feedback-content');
 
             $(document).ready(function () {
 
@@ -317,7 +326,11 @@
         });
 
         $('#feedback-technical-item').click(function (e) {
-            return feedback.switchState(TECHNICAL);
+            return feedback.switchState(TECHNICAL, REPORTTECHNICAL);
+        });
+
+        $('#feedback-helpdesk-item').click(function (e) {
+            return feedback.switchState(TECHNICAL, REPORTHELPDESK);
         });
 
         if (feedback.helpPagesUrl.length > 0 ) {


### PR DESCRIPTION
This change is to use a different subject line in the email if they click on 'Ask for Help' vs 'Technical Problem' (they use the same handlebars template and url)

I've made a new entitybroker url  for 'Ask for Help' (like the others) and I feed a 'HELPDESK' constant through to tell if they clicked on 'Ask for Help' rather than 'Technical Problem'.  This means that the enum column type of sakai_feedback.report_type needs to be extended also.  (There is also a script attached to the JIRA to alter the column data type).      
