### PR TITLE
WL-3708 : Javascript error from newline \n character in properties file

### DIFF
--- a/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -238,7 +238,7 @@ public class SakaiProxy {
 
 
         if (feedbackType.equals(Constants.CONTENT)) {
-            formattedBody = formattedBody + rb.getString("email_body_template_note");
+            formattedBody = formattedBody + "\n\n\n" + rb.getString("email_body_template_note");
         }
 
 

--- a/src/main/resources/org/sakaiproject/feedback.properties
+++ b/src/main/resources/org/sakaiproject/feedback.properties
@@ -125,4 +125,4 @@ Summary\
 ----------------\
 {11}\
 {10}
-email_body_template_note = \n\n\nYou can manage your visibility in this and other sites. To do this, visit My Workspace, select Preferences, then click on Privacy Status to control your visibility (in all tools) within a specified site. Please consider the impact that this will have on users of your site should they have a problem.
+email_body_template_note = You can manage your visibility in this and other sites. To do this, visit My Workspace, select Preferences, then click on Privacy Status to control your visibility (in all tools) within a specified site. Please consider the impact that this will have on users of your site should they have a problem.

--- a/src/main/resources/org/sakaiproject/feedback_en_GB.properties
+++ b/src/main/resources/org/sakaiproject/feedback_en_GB.properties
@@ -125,4 +125,4 @@ Summary\
 ----------------\
 {11}\
 {10}
-email_body_template_note = \n\n\nYou can manage your visibility in this and other sites. To do this, visit My Workspace, select Preferences, then click on Privacy Status to control your visibility (in all tools) within a specified site. Please consider the impact that this will have on users of your site should they have a problem.
+email_body_template_note = You can manage your visibility in this and other sites. To do this, visit My Workspace, select Preferences, then click on Privacy Status to control your visibility (in all tools) within a specified site. Please consider the impact that this will have on users of your site should they have a problem.


### PR DESCRIPTION
'\n' doesn't work in feedback submodule properties files
as the backslash has a special meaning in them (as a sign that there's more
 of the property to come on the next line).
I've put in the Java instead.
