### PR TITLE
WL-3643 : Minor UI tweaks

### DIFF
--- a/src/webapp/css/feedback.css
+++ b/src/webapp/css/feedback.css
@@ -119,8 +119,8 @@
     float: left;
     list-style: none outside none;
     margin: 2px;
-    height: 23em;
-    padding: 2px 10px;
+    height: 24em;
+    padding: 2px 8px;
     width: 175px;
 }
 


### PR DESCRIPTION
The text in Firefox was too close to the bottom of box so I increased the box height. Looks fine in other browsers.

And the boxes spilt onto two lines in MSIE and Chrome so I decreased the padding for them.  Looks fine in Firefox.
