### PR TITLE
WL-3663: If site doesn't exist, don't try to collect information on it

### DIFF
--- a/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
+++ b/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
@@ -120,6 +120,7 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
 
         final String title = (String) params.get("title");
         final String description = (String) params.get("description");
+        final boolean siteExists = new Boolean((String)params.get("siteExists"));
 
         if (title == null || title.isEmpty()) {
 			logger.debug("Subject incorrect. Returning " + BAD_TITLE + " ...");
@@ -204,7 +205,7 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
         
             try {
                 attachments = getAttachments(params);
-                sakaiProxy.sendEmail(userId, senderAddress, toAddress, addNoContactMessage, siteId, type, title, description, attachments);
+                sakaiProxy.sendEmail(userId, senderAddress, toAddress, addNoContactMessage, siteId, type, title, description, attachments, siteExists);
                 db.logReport(userId, senderAddress, siteId, type, title, description);
                 return SUCCESS;
             } catch (AttachmentsTooBigException atbe) {

--- a/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -141,7 +141,7 @@ public class SakaiProxy {
 
 	public void sendEmail(String fromUserId, String senderAddress, String toAddress, boolean addNoContactEmailMessage, String siteId, String feedbackType
                             , String userTitle, String userContent
-                            , List<FileItem> fileItems) {
+                            , List<FileItem> fileItems, boolean siteExists) {
 
 		final List<Attachment> attachments = new ArrayList<Attachment>();
 
@@ -213,9 +213,9 @@ public class SakaiProxy {
 
         final Site site = getSite(siteId);
 
-        final String siteTitle = site.getTitle();
+        final String siteTitle = siteExists ? site.getTitle() : "N/A (Site does not exist)";
 
-        final String siteUrl = serverConfigurationService.getPortalUrl() + "/site/" + site.getId();
+        final String siteUrl = serverConfigurationService.getPortalUrl() + "/site/" + (siteExists ? site.getId() : siteId) ;
 
         String noContactEmailMessage = "";
         

--- a/src/webapp/WEB-INF/bootstrap.jsp
+++ b/src/webapp/WEB-INF/bootstrap.jsp
@@ -20,6 +20,7 @@
                 state: 'home',
                 userId: '${userId}',
                 siteId: '${siteId}',
+                siteExists: '${siteExists}',
                 language: '${language}',
                 featureSuggestionUrl: '${featureSuggestionUrl}',
                 technicalToAddress: '${technicalToAddress}',

--- a/src/webapp/WEB-INF/templates/content.handlebars
+++ b/src/webapp/WEB-INF/templates/content.handlebars
@@ -27,6 +27,7 @@
         <tr id="feedback-sender-address"><td>{{translate 'sender_address_label'}}</td><td><input type="text" name="senderaddress" size="40"/></td></tr>
     </table>
     <input id="feedback-technical-email" value="{{technicalToAddress}}" hidden="hidden"/>
+    <input type="hidden" name="siteExists" value="{{siteExists}}"/>
     <div id="feedback-attachments-label">
         <span>{{translate 'attachments_label'}}</span>
         <span id="feedback-max-attachments-label">

--- a/src/webapp/WEB-INF/templates/technical.handlebars
+++ b/src/webapp/WEB-INF/templates/technical.handlebars
@@ -15,6 +15,7 @@
         <tr id="feedback-sender-address"><td>{{translate 'sender_address_label'}}</td><td><input type="text" name="senderaddress" size="40"/></td></tr>
     </table>
     <input id="feedback-technical-email" value="{{technicalToAddress}}" hidden="hidden"/>
+    <input type="hidden" name="siteExists" value="{{siteExists}}"/>
     <div id="feedback-attachments-label">
         <span>{{translate 'attachments_label'}}</span>
         <span id="feedback-max-attachments-label">

--- a/src/webapp/js/feedback.js
+++ b/src/webapp/js/feedback.js
@@ -110,7 +110,7 @@
             });
         } else if (CONTENT === state) {
 
-            feedback.utils.renderTemplate(state, { siteId: feedback.siteId, siteUpdaters: feedback.siteUpdaters, loggedIn: loggedIn, technicalToAddress: feedback.technicalToAddress, contactName: feedback.contactName}, 'feedback-content');
+            feedback.utils.renderTemplate(state, { siteExists: feedback.siteExists, siteId: feedback.siteId, siteUpdaters: feedback.siteUpdaters, loggedIn: loggedIn, technicalToAddress: feedback.technicalToAddress, contactName: feedback.contactName}, 'feedback-content');
 
             $(document).ready(function () {
 
@@ -142,7 +142,7 @@
             });
         } else if (TECHNICAL === state) {
 
-            feedback.utils.renderTemplate(state, { url: url, siteId: feedback.siteId, siteUpdaters: feedback.siteUpdaters, loggedIn: loggedIn, technicalToAddress: feedback.technicalToAddress, contactName: feedback.contactName }, 'feedback-content');
+            feedback.utils.renderTemplate(state, { siteExists: feedback.siteExists, url: url, siteId: feedback.siteId, siteUpdaters: feedback.siteUpdaters, loggedIn: loggedIn, technicalToAddress: feedback.technicalToAddress, contactName: feedback.contactName }, 'feedback-content');
 
             $(document).ready(function () {
 


### PR DESCRIPTION
We want to include the 'siteId' in the Contact Us tool's email for non-existent sites so, when the site does not exist, we don't try to get its id, reference, etc.  

Since we're putting 'siteId' in the email, we also need to pass it through along the usual route via handelbars to the email sender. 
